### PR TITLE
fix: allow relative base

### DIFF
--- a/spec/index.test.js
+++ b/spec/index.test.js
@@ -3,12 +3,55 @@ import { baseUrl } from '../src/index.js';
 
 describe('baseUrl', () => {
   beforeEach(() => {
-    marked.setOptions(marked.getDefaults());
+    const opts = marked.getDefaults();
+    opts['mangle'] = false; // to temporarily disable the warning message
+    opts['headerIds'] = false; // to temporarily disable the warning message
+    marked.setOptions(opts);
   });
 
-  test('domain', () => {
+  test('domain vs locally absolute path', () => {
     marked.use(baseUrl('https://example.com/'));
     expect(marked.parse('[my url](/relative)')).toMatchInlineSnapshot(`
+"<p><a href="https://example.com/relative">my url</a></p>
+"
+`);
+  });
+
+  test('domain vs relative path bare', () => {
+    marked.use(baseUrl('https://example.com/'));
+    expect(marked.parse('[my url](relative)')).toMatchInlineSnapshot(`
+"<p><a href="https://example.com/relative">my url</a></p>
+"
+`);
+  });
+
+  test('domain vs relative path', () => {
+    marked.use(baseUrl('https://example.com/'));
+    expect(marked.parse('[my url](./relative)')).toMatchInlineSnapshot(`
+"<p><a href="https://example.com/relative">my url</a></p>
+"
+`);
+  });
+
+  test('domain without trailing slash vs locally absolute path', () => {
+    marked.use(baseUrl('https://example.com'));
+    expect(marked.parse('[my url](/relative)')).toMatchInlineSnapshot(`
+"<p><a href="https://example.com/relative">my url</a></p>
+"
+`);
+  });
+
+  test('domain without trailing slash vs relative path bare', () => {
+    marked.use(baseUrl('https://example.com'));
+    expect(marked.parse('[my url](relative)')).toMatchInlineSnapshot(`
+"<p><a href="https://example.com/relative">my url</a></p>
+"
+`);
+  });
+
+  test('domain without trailing slash vs relative path', () => {
+    marked.use(baseUrl('https://example.com'));
+    expect(marked.parse('[my url](./relative)')).toMatchInlineSnapshot(`
 "<p><a href="https://example.com/relative">my url</a></p>
 "
 `);
@@ -22,7 +65,7 @@ describe('baseUrl', () => {
 `);
   });
 
-  test('domain folder base', () => {
+  test('domain folder base vs locally absolute path', () => {
     marked.use(baseUrl('https://example.com/folder'));
     expect(marked.parse('[my url](/relative)')).toMatchInlineSnapshot(`
 "<p><a href="https://example.com/relative">my url</a></p>
@@ -30,7 +73,7 @@ describe('baseUrl', () => {
 `);
   });
 
-  test('domain folder base trailing slash', () => {
+  test('domain folder base trailing slash vs locally absolute path', () => {
     marked.use(baseUrl('https://example.com/folder/'));
     expect(marked.parse('[my url](/relative)')).toMatchInlineSnapshot(`
 "<p><a href="https://example.com/relative">my url</a></p>
@@ -38,18 +81,74 @@ describe('baseUrl', () => {
 `);
   });
 
-  test('domain folder', () => {
+  test('domain folder vs relative path', () => {
     marked.use(baseUrl('https://example.com/folder'));
     expect(marked.parse('[my url](./relative)')).toMatchInlineSnapshot(`
-"<p><a href="https://example.com/relative">my url</a></p>
+"<p><a href="https://example.com/folder/relative">my url</a></p>
 "
 `);
   });
 
-  test('domain folder trailing slash', () => {
+  test('domain folder trailing slash vs relative path', () => {
     marked.use(baseUrl('https://example.com/folder/'));
     expect(marked.parse('[my url](./relative)')).toMatchInlineSnapshot(`
 "<p><a href="https://example.com/folder/relative">my url</a></p>
+"
+`);
+  });
+
+  test('domain folder trailing slash vs relative path bare', () => {
+    marked.use(baseUrl('https://example.com/folder/'));
+    expect(marked.parse('[my url](relative)')).toMatchInlineSnapshot(`
+"<p><a href="https://example.com/folder/relative">my url</a></p>
+"
+`);
+  });
+
+  test('relative baseUrl vs relative path', () => {
+    marked.use(baseUrl('folder'));
+    expect(marked.parse('[my url](relative)')).toMatchInlineSnapshot(`
+"<p><a href="folder/relative">my url</a></p>
+"
+`);
+  });
+
+  test('locally absolute baseUrl vs relative path', () => {
+    marked.use(baseUrl('/folder'));
+    expect(marked.parse('[my url](./relative)')).toMatchInlineSnapshot(`
+"<p><a href="/folder/relative">my url</a></p>
+"
+`);
+  });
+
+  test('relative baseUrl vs locally absolute path', () => {
+    marked.use(baseUrl('folder'));
+    expect(marked.parse('[my url](/relative)')).toMatchInlineSnapshot(`
+"<p><a href="/relative">my url</a></p>
+"
+`);
+  });
+
+  test('locally absolute baseUrl vs locally absolute path', () => {
+    marked.use(baseUrl('/folder'));
+    expect(marked.parse('[my url](/relative)')).toMatchInlineSnapshot(`
+"<p><a href="/relative">my url</a></p>
+"
+`);
+  });
+
+  test('absolute url, jump up', () => {
+    marked.use(baseUrl('http://example.com/a/b/c/'));
+    expect(marked.parse('[my url](../relative)')).toMatchInlineSnapshot(`
+"<p><a href="http://example.com/a/b/relative">my url</a></p>
+"
+`);
+  });
+
+  test('locally absolute url, jump up', () => {
+    marked.use(baseUrl('/a/b/c/'));
+    expect(marked.parse('[my url](../relative)')).toMatchInlineSnapshot(`
+"<p><a href="/a/b/relative">my url</a></p>
 "
 `);
   });

--- a/spec/index.test.js
+++ b/spec/index.test.js
@@ -4,8 +4,8 @@ import { baseUrl } from '../src/index.js';
 describe('baseUrl', () => {
   beforeEach(() => {
     const opts = marked.getDefaults();
-    opts['mangle'] = false; // to temporarily disable the warning message
-    opts['headerIds'] = false; // to temporarily disable the warning message
+    opts.mangle = false; // to temporarily disable the warning message
+    opts.headerIds = false; // to temporarily disable the warning message
     marked.setOptions(opts);
   });
 

--- a/spec/index.test.js
+++ b/spec/index.test.js
@@ -129,6 +129,14 @@ describe('baseUrl', () => {
 `);
   });
 
+  test('unchanged as baseUrl is not a folder', () => {
+    marked.use(baseUrl('folder'));
+    expect(marked.parse('[my url](relative)')).toMatchInlineSnapshot(`
+"<p><a href="relative">my url</a></p>
+"
+`);
+  });
+
   test('locally absolute baseUrl vs locally absolute path', () => {
     marked.use(baseUrl('/folder'));
     expect(marked.parse('[my url](/relative)')).toMatchInlineSnapshot(`

--- a/spec/index.test.js
+++ b/spec/index.test.js
@@ -81,10 +81,10 @@ describe('baseUrl', () => {
 `);
   });
 
-  test('domain folder vs relative path', () => {
-    marked.use(baseUrl('https://example.com/folder'));
+  test('domain file vs relative path', () => {
+    marked.use(baseUrl('https://example.com/file.html'));
     expect(marked.parse('[my url](./relative)')).toMatchInlineSnapshot(`
-"<p><a href="https://example.com/folder/relative">my url</a></p>
+"<p><a href="https://example.com/relative">my url</a></p>
 "
 `);
   });
@@ -106,7 +106,7 @@ describe('baseUrl', () => {
   });
 
   test('relative baseUrl vs relative path', () => {
-    marked.use(baseUrl('folder'));
+    marked.use(baseUrl('folder/file.html'));
     expect(marked.parse('[my url](relative)')).toMatchInlineSnapshot(`
 "<p><a href="folder/relative">my url</a></p>
 "
@@ -114,7 +114,7 @@ describe('baseUrl', () => {
   });
 
   test('locally absolute baseUrl vs relative path', () => {
-    marked.use(baseUrl('/folder'));
+    marked.use(baseUrl('/folder/file.html'));
     expect(marked.parse('[my url](./relative)')).toMatchInlineSnapshot(`
 "<p><a href="/folder/relative">my url</a></p>
 "

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ export function baseUrl(baseUrl) {
   // extension code here
 
   const reAbsUrl = /^[\w+]+:\/\//;
-  baseUrl = baseUrl.trim().replaceAll(/[\/\.]+$/g, '') + '/'; // make sure baseUrl ends with one '/'
+  baseUrl = baseUrl.trim().replaceAll(/[\/]+$/g, '/'); // if multiple '/' at the end, just keep one
   return {
     walkTokens(token) {
       if (!['link', 'image'].includes(token.type)) {
@@ -22,7 +22,7 @@ export function baseUrl(baseUrl) {
         try {
           const baseUrlFromRoot = baseUrl.startsWith('/');
           const dummy = 'http://__dummy__';
-          const temp = new URL(baseUrl + token.href, dummy).href;
+          const temp = new URL(token.href, new URL(baseUrl, dummy)).href;
           token.href = temp.slice(dummy.length + (baseUrlFromRoot ? 0 : 1));
         } catch (e) {
           // ignore

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,8 @@
 export function baseUrl(baseUrl) {
   // extension code here
 
-  const reAbsUrl = /^[\w+]+:\/\//
-  baseUrl = baseUrl.trim().replaceAll(/[\/\.]+$/g, '')+'/'  // make sure baseUrl ends with one '/'
+  const reAbsUrl = /^[\w+]+:\/\//;
+  baseUrl = baseUrl.trim().replaceAll(/[\/\.]+$/g, '') + '/'; // make sure baseUrl ends with one '/'
   return {
     walkTokens(token) {
       if (!['link', 'image'].includes(token.type)) {
@@ -15,15 +15,15 @@ export function baseUrl(baseUrl) {
       }
       if (!reAbsUrl.test(baseUrl)) {
         // baseUrl is not absolute
-        if (token.href.startsWith("/")) {
+        if (token.href.startsWith('/')) {
           // the URL is from root
-          return
+          return;
         }
         try {
-          const baseUrlFromRoot = baseUrl.startsWith('/')
-          const dummy = 'http://__dummy__'
-          const temp = new URL(baseUrl+token.href, dummy).href
-          token.href = temp.slice(dummy.length + (baseUrlFromRoot ? 0 : 1))
+          const baseUrlFromRoot = baseUrl.startsWith('/');
+          const dummy = 'http://__dummy__';
+          const temp = new URL(baseUrl + token.href, dummy).href;
+          token.href = temp.slice(dummy.length + (baseUrlFromRoot ? 0 : 1));
         } catch (e) {
           // ignore
         }

--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,39 @@
-export function baseUrl(base) {
+export function baseUrl(baseUrl) {
   // extension code here
 
+  const reAbsUrl = /^[\w+]+:\/\//
+  baseUrl = baseUrl.trim().replaceAll(/[\/\.]+$/g, '')+'/'  // make sure baseUrl ends with one '/'
   return {
     walkTokens(token) {
       if (!['link', 'image'].includes(token.type)) {
         return;
       }
 
-      token.href = new URL(token.href, base).href;
+      if (reAbsUrl.test(token.href)) {
+        // keep the URL intact if absolute
+        return;
+      }
+      if (!reAbsUrl.test(baseUrl)) {
+        // baseUrl is not absolute
+        if (token.href.startsWith("/")) {
+          // the URL is from root
+          return
+        }
+        try {
+          const baseUrlFromRoot = baseUrl.startsWith('/')
+          const dummy = 'http://__dummy__'
+          const temp = new URL(baseUrl+token.href, dummy).href
+          token.href = temp.slice(dummy.length + (baseUrlFromRoot ? 0 : 1))
+        } catch (e) {
+          // ignore
+        }
+      } else {
+        try {
+          token.href = new URL(token.href, baseUrl).href;
+        } catch (e) {
+          // ignore
+        }
+      }
     }
   };
 }


### PR DESCRIPTION
Those use cases are correctly handled:

- {baseUrl: https://example.com/, link: /relative} ==> https://example.com/relative
- {baseUrl: https://example.com/, link: relative} ==> https://example.com/relative
- {baseUrl: https://example.com/, link: ./relative} ==> https://example.com/relative
- {baseUrl: https://example.com, link: /relative} ==> https://example.com/relative
- {baseUrl: https://example.com, link: relative} ==> https://example.com/relative
- {baseUrl: https://example.com, link: ./relative} ==> https://example.com/relative
- {baseUrl: https://example.com/, link: https://example.org/absolute} ==> https://example.org/absolute
- {baseUrl: https://example.com/folder, link: /relative} ==> https://example.com/relative
- {baseUrl: https://example.com/folder/, link: /relative} ==> https://example.com/relative
- {baseUrl: https://example.com/file.html, link: ./relative} ==> https://example.com/relative
- {baseUrl: https://example.com/folder/, link: ./relative} ==> https://example.com/folder/relative
- {baseUrl: https://example.com/folder/, link: relative} ==> https://example.com/folder/relative
- {baseUrl: file.txt, link: relative} ==> relative
- {baseUrl: /folder/file.html, link: ./relative} ==> /folder/relative
- {baseUrl: folder, link: /relative} ==> /relative
- {baseUrl: /folder, link: /relative} ==> /relative
- {baseUrl: http://example.com/a/b/c/, link: ../relative} ==> http://example.com/a/b/relative
- {baseUrl: /a/b/c/, link: ../relative} ==> /a/b/relative
