### PR TITLE
fix: keep URL intact if it is absolute

### DIFF
--- a/spec/index.test.js
+++ b/spec/index.test.js
@@ -65,6 +65,22 @@ describe('baseUrl', () => {
 `);
   });
 
+  test('absolute path vs relative baseUrl', () => {
+    marked.use(baseUrl('./relative/folder/'));
+    expect(marked.parse('[my url](https://example.org/absolute)')).toMatchInlineSnapshot(`
+"<p><a href="https://example.org/absolute">my url</a></p>
+"
+`);
+  });
+
+  test('absolute path vs root baseUrl', () => {
+    marked.use(baseUrl('/root/folder/'));
+    expect(marked.parse('[my url](https://example.org/absolute)')).toMatchInlineSnapshot(`
+"<p><a href="https://example.org/absolute">my url</a></p>
+"
+`);
+  });
+
   test('domain folder base vs locally absolute path', () => {
     marked.use(baseUrl('https://example.com/folder'));
     expect(marked.parse('[my url](/relative)')).toMatchInlineSnapshot(`

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,8 @@ export function baseUrl(base) {
   // extension code here
 
   base = base.trim().replace(/\/+$/, '/'); // if multiple '/' at the end, just keep one
-  const isBaseAbsolute = /^[\w+]+:\/\//.test(base);
+  const reIsAbsolute = /^[\w+]+:\/\//;
+  const isBaseAbsolute = reIsAbsolute.test(base);
   const dummyUrl = 'http://__dummy__';
   const dummyBaseUrl = new URL(base, dummyUrl);
   const dummyUrlLength = dummyUrl.length + (base.startsWith('/') ? 0 : 1);
@@ -10,6 +11,11 @@ export function baseUrl(base) {
   return {
     walkTokens(token) {
       if (!['link', 'image'].includes(token.type)) {
+        return;
+      }
+
+      if (reIsAbsolute.test(token.href)) {
+        // the URL is absolute, do not touch it
         return;
       }
 


### PR DESCRIPTION
This PR fixes a bug where the URL is absolute.

E.g. `marked.parse('[my url](https://example.org/absolute)')` should produce output `<p><a href="https://example.org/absolute">my url</a></p>` regardless of the `baseUrl`.

The current code produces the following:

```

  ● baseUrl › absolute path vs relative baseUrl                                                                                                                    
                                                                                                                                                                   
    expect(received).toMatchInlineSnapshot(snapshot)

    Snapshot name: `baseUrl absolute path vs relative baseUrl 1`

    - Snapshot  - 1
    + Received  + 1

    - "<p><a href="https://example.org/absolute">my url</a></p>
    + "<p><a href="rg/absolute">my url</a></p>
      "

      68 |   test('absolute path vs relative baseUrl', () => {
      69 |     marked.use(baseUrl('./relative/folder/'));
    > 70 |     expect(marked.parse('[my url](https://example.org/absolute)')).toMatchInlineSnapshot(`
         |                                                                    ^
      71 | "<p><a href="https://example.org/absolute">my url</a></p>
      72 | "
      73 | `);

      at Object.toMatchInlineSnapshot (spec/index.test.js:70:68)

  ● baseUrl › absolute path vs root baseUrl

    expect(received).toMatchInlineSnapshot(snapshot)

    Snapshot name: `baseUrl absolute path vs root baseUrl 1`

    - Snapshot  - 1
    + Received  + 1

    - "<p><a href="https://example.org/absolute">my url</a></p>
    + "<p><a href="org/absolute">my url</a></p>
      "

      76 |   test('absolute path vs root baseUrl', () => {
      77 |     marked.use(baseUrl('/root/folder/'));
    > 78 |     expect(marked.parse('[my url](https://example.org/absolute)')).toMatchInlineSnapshot(`
         |                                                                    ^
      79 | "<p><a href="https://example.org/absolute">my url</a></p>
      80 | "
      81 | `);

      at Object.toMatchInlineSnapshot (spec/index.test.js:78:68)

 › 2 snapshots failed.
```